### PR TITLE
Extract links acts and reg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ Llama-3.2*
 vllm/
 static/
 src/CLaRA*
+
+# Ignore all files in collections folder except specific ones
+collections/*
+!collections/equity.json
+!collections/labour.json
+!collections/example.json.txt

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,8 @@ src/RAG_Agent*
 Modelfile
 .docker
 chroma_vectorDB
-scripts/outputs
-/inputs
 /outputs
+/extracted_data
 collections.csv
 sparse_logs
 Llama-3.2*

--- a/README.md
+++ b/README.md
@@ -185,7 +185,11 @@ The application can be customized for your own use case by creating new database
    - **`languages`**: List of language codes (e.g., `["en", "fr"]`) that your database supports.
    - **`ressource_name`**: Dictionary mapping language codes to display names for the UI (e.g., `{"en": "Labour", "fr": "Travail"}`).
 3. **Add your data sources** using these supported formats.
-   - **Web pages**: Add URLs under the `"page"` key, organized by language
+   - **Web pages**: Add URLs under the `"page"` key, organized by language. Each web page entry is a tuple with format `("NAME", "URL", depth)` where:
+     - `depth = 0`: Extract only the page itself
+     - `depth = 1`: Extract the page and all links within it
+     - `depth = 2`: Extract the page, all links within it, and links within those links (2 levels deep)
+     - Maximum depth limit is 2
    - **Legal pages**: Add law URLs under the `"law"` key, organized by language
    - **IPG pages**: Add IPG URLs under the `"ipg"` key, organized by language
    - **PDF files**: Add URLs or local file paths under the `"pdf"` key, organized by language

--- a/README.md
+++ b/README.md
@@ -179,21 +179,24 @@ The application can be customized for your own use case by creating new database
 
 ### Configuration
 
-1. **Edit the database configuration** in [`db_config.py`](./db_config.py), inside the 'VectorDBDataFiles' dataclass.
-2. **Configure database metadata**:
-   - **`is_default`**: Set to `True` to make this database the default selection in the UI.
-   - **`languages`**: List of language codes (e.g., `["en", "fr"]`) that your database supports.
-   - **`ressource_name`**: Dictionary mapping language codes to display names for the UI (e.g., `{"en": "Labour", "fr": "Travail"}`).
-3. **Add your data sources** using these supported formats.
-   - **Web pages**: Add URLs under the `"page"` key, organized by language. Each web page entry is a tuple with format `("NAME", "URL", depth)` where:
+1. **Create or edit database configuration files** in the [`collections/`](./collections/) folder. Each database is defined by a JSON file in this directory.
+2. **Configure database metadata** in your JSON file:
+   - **`name`**: The database identifier
+   - **`is_default`**: Set to `true` to make this database the default selection in the UI
+   - **`save_html`**: Set to `true` to save HTML content locally
+   - **`languages`**: List of language codes (e.g., `["en", "fr"]`) that your database supports
+   - **`ressource_name`**: Dictionary mapping language codes to display names for the UI (e.g., `{"en": "Labour", "fr": "Travail"}`)
+3. **Add your data sources** using these supported formats, organized by language:
+   - **Web pages**: Add URLs under the `"page"` key. Each web page entry is an array with format `["NAME", "URL", depth]` where:
      - `depth = 0`: Extract only the page itself
      - `depth = 1`: Extract the page and all links within it
      - `depth = 2`: Extract the page, all links within it, and links within those links (2 levels deep)
      - Maximum depth limit is 2
-   - **Legal pages**: Add law URLs under the `"law"` key, organized by language
+   - **Legal pages**: Add law URLs under the `"law"` key as arrays with format `["name", "URL"]`
    - **IPG pages**: Add IPG URLs under the `"ipg"` key, organized by language
    - **PDF files**: Add URLs or local file paths under the `"pdf"` key, organized by language
-   - **Note**: Data sources must be organized by language codes (e.g., `"en"`, `"fr"`). You can support one or more languages per database:
+   - **Page blacklist**: Add URLs to exclude under the `"page_blacklist"` key, organized by language
+   - **Note**: Data sources must be organized by language codes (e.g., `"en"`, `"fr"`). You can support one or more languages per database
 
 ### Supported Data Sources
 
@@ -208,6 +211,11 @@ Run the database creation script:
 ./setup/create_or_update_database.sh
 ```
 
+**Optional Transport Database**: To create the 'transport' database that contains all Canada acts and regulations related to transport, uncomment the following line in `setup/create_or_update_database.sh` before running the script:
+```bash
+#python ./scripts/extract_links_transport_acts_and_reg.py &&
+```
+
 This script will:
 1. Extract content from all configured sources
 2. Process and chunk the documents
@@ -217,7 +225,7 @@ This script will:
 
 - **PDF files** are automatically downloaded to the `static/` folder for offline access
 - **Static files** are accessible via `app/static/...` URLs within the application
-- **Note**: Removing a database from the config file doesn't delete its files from the `static/` folder
+- **Note**: Removing a database JSON file doesn't delete its files from the `static/` folder
 
 <!-- USAGE EXAMPLES -->
 ## Use Case and Portability

--- a/chatbot_app.py
+++ b/chatbot_app.py
@@ -28,7 +28,7 @@ class App:
         self.model = self.config.default_model_local if not self.is_remote else self.config.default_model_remote
         self.nb_previous_questions = self.config.nb_previous_questions
 
-        databases = VectorDBDataFiles.databases
+        databases = VectorDBDataFiles.databases()
 
         # The first db where is_default is True (first one otherwise)
         self.db_name = next((db for db in databases if db.get("is_default", False)), databases[0] if len(databases) > 0 else None)
@@ -90,7 +90,7 @@ class App:
                                 options=model_shortlist, 
                                 index=model_shortlist.index(default_model))
             
-            databases = VectorDBDataFiles.databases
+            databases = VectorDBDataFiles.databases()
 
             def translate_db_name(db):
                 # Try to get the current language, if not available, get the first available language
@@ -107,7 +107,7 @@ class App:
                                 options=list(translated_db_list), 
                                 index=translated_db_list.index(translated_db_name))
             
-            orig_db_list = list([db["name"] for db in VectorDBDataFiles.databases])
+            orig_db_list = list([db["name"] for db in VectorDBDataFiles.databases()])
             self.db_name = orig_db_list[translated_db_list.index(selected_db_name)]
             
             sources_number = st.number_input(self.translator.get('sidebar.sources_prompt'), 

--- a/collections/equity.json
+++ b/collections/equity.json
@@ -1,0 +1,28 @@
+{
+    "name": "equity",
+    "languages": ["en", "fr"],
+    "ressource_name": {
+        "en": "Equity",
+        "fr": "Équité"
+    },
+    "pdf": {
+        "en": [
+            "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-WEDWEIMSUserGuide-20220224-PDF%20(1).pdf",
+            "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/EmployerOnboardingGuide-LEEP-2024.pdf",
+            "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/Taking%20action%20on%20your%20employment%20equity%20data.pdf",
+            "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-WEDWorkshopHowToInterpretForm2,%20parts%20D-G-20220427.pdf",
+            "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-WEDStep-by-step%20guide%20for%20annual%20Legislated%20Employment%20Equity%20Program%20(LEEP)%20reporting.pdf",
+            "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/EmployerOnboardingGuide-FCP-2024.pdf",
+            "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-WEDHowToImproveWorkplaceEquity-20230308-PDF.pdf"
+        ],
+        "fr": [
+            "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-WEDWEIMSUserGuideFR-20220224-PDF%20(1).pdf",
+            "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/GuideDIntegrationPourLesEmployeurs-PLEME-2024.pdf",
+            "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/Agir%20a%20partir%20de%20vos%20donnees%20sur%20l%20equite%20en%20emploi.pdf",
+            "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-WEDAtelierCommentInterpreterVotreFormulaire%202,%20parties%20D-G-20220428.pdf",
+            "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-Guide%20de%20preparation%20etape%20par%20etape%20du%20rapport%20annuel%20du%20Programme%20legifere%20dequite%20en%20matiere%20demploi%20(PLEME).pdf",
+            "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/GuideDIntegrationPourLesEmployeurs-PCF-2024.pdf",
+            "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-WEDCommentAmeliorerLequiteSurLeLieuDuTravailFR-20230308-PDF.pdf"
+        ]
+    }
+}

--- a/collections/example.json.txt
+++ b/collections/example.json.txt
@@ -1,0 +1,48 @@
+{
+    "name": "another_use_case",
+    "is_default": true,           #<----- If True, this will be the default database in the app (if true for multiple databases, the first one will be the default)
+    "save_html": true,            #<----- If True, the html files of all web pages will be saved in the "outputs" folder
+    "languages": ["en", "fr"],    #<----- List of language codes that your database supports
+    "ressource_name": {           #<----- Dictionary mapping language codes to display names for the UI
+        "en": "Another use case"
+    },
+
+    # PDF files: Add URLs or local file paths organized by language
+    "pdf": {                      
+        "en": [
+            "https://www.example.com/pdf/example.pdf",      #<----- Remote PDF URL
+            "C:/local/documents/example.pdf",               #<----- Local PDF file path
+            "../documents/pdf_folder/"                      #<----- Local folder containing PDFs
+        ]
+    },
+
+    # IPG pages: Add IPG URLs organized by language
+    "ipg": {                      
+        "en": "https://www.canada.ca/en/employment-social-development/programs/laws-regulations/labour/interpretations-policies.html"
+    },
+
+    # Legal pages: Add law URLs organized by language. Format: ["name", "url"]
+    "law": {
+        "en": [
+            ["example_act", "https://laws-lois.justice.gc.ca/eng/acts/e-1/"],
+            ["example_regulations", "https://laws-lois.justice.gc.ca/eng/regulations/C.R.C.,_c._123/"]
+        ]
+    },
+
+    # Web pages: Add URLs organized by language. Format: ["NAME", "URL", depth]
+    "page": {                     
+        "en": [                   
+            ["MAIN_PAGE", "https://www.example.com/en/main.html", 0],        #<----- depth = 0: Extract only the page itself
+            ["SERVICES", "https://www.example.com/en/services.html", 1],     #<----- depth = 1: Extract the page and all links within it
+            ["RESOURCES", "https://www.example.com/en/resources.html", 2]    #<----- depth = 2 (Max depth): Extract the page, all links within it, and links within those links
+        ]
+    },
+    
+    # Optional: URLs to exclude from extraction during web crawling
+    "page_blacklist": {           
+        "en": [
+            "/en/news/",                                    #<----- Exclude news pages
+            "/en/contact.html"                              #<----- Exclude contact pages
+        ]
+    }
+}

--- a/collections/example.json.txt
+++ b/collections/example.json.txt
@@ -1,7 +1,7 @@
 {
     "name": "another_use_case",
     "is_default": true,           #<----- If True, this will be the default database in the app (if true for multiple databases, the first one will be the default)
-    "save_html": true,            #<----- If True, the html files of all web pages will be saved in the "outputs" folder
+    "save_html": true,            #<----- If True, the html files of all web pages will be saved in the "extracted_data" folder
     "languages": ["en", "fr"],    #<----- List of language codes that your database supports
     "ressource_name": {           #<----- Dictionary mapping language codes to display names for the UI
         "en": "Another use case"

--- a/collections/labour.json
+++ b/collections/labour.json
@@ -1,0 +1,53 @@
+{
+    "name": "labour",
+    "is_default": true,
+    "save_html": true,
+    "languages": ["en", "fr"],
+    "ressource_name": {
+        "en": "Labour",
+        "fr": "Travail"
+    },
+    "ipg": {
+        "en": "https://www.canada.ca/en/employment-social-development/programs/laws-regulations/labour/interpretations-policies.html",
+        "fr": "https://www.canada.ca/fr/emploi-developpement-social/programmes/lois-reglements/travail/interpretations-politiques.html"
+    },
+    "law": {
+        "en": [
+            ["clc", "https://laws-lois.justice.gc.ca/eng/acts/l-2/"],
+            ["clsr", "https://laws-lois.justice.gc.ca/eng/regulations/C.R.C.,_c._986/"]
+
+        ],
+        "fr": [
+            ["clc", "https://laws-lois.justice.gc.ca/fra/lois/l-2/"],
+            ["clsr", "https://laws-lois.justice.gc.ca/fra/reglements/C.R.C.%2C_ch._986/"]
+        ]
+    },
+    "page": {
+        "en": [
+            ["LABOUR", "https://www.canada.ca/en/employment-social-development/corporate/portfolio/labour.html", 1],
+            ["WORKPLACE", "https://www.canada.ca/en/services/jobs/workplace.html", 1],
+            ["LABOUR-REPORTS", "https://www.canada.ca/en/employment-social-development/corporate/portfolio/labour/programs/labour-standards/reports.html", 1],
+            ["LABOUR-STANDARDS", "https://www.canada.ca/en/services/jobs/workplace/federal-labour-standards.html", 1],
+            ["COMPENSATION", "https://www.canada.ca/en/services/jobs/workplace/health-safety/compensation.html", 1],
+            ["HEALTH-SAFETY", "https://www.canada.ca/en/services/jobs/workplace/health-safety.html", 1]
+        ],
+        "fr": [
+            ["LABOUR", "https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/travail.html", 1],
+            ["WORKPLACE", "https://www.canada.ca/fr/services/emplois/milieu-travail.html", 1],
+            ["LABOUR-REPORTS", "https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/travail/programmes/normes-travail/rapports.html", 1],
+            ["LABOUR-STANDARDS", "https://www.canada.ca/fr/services/emplois/milieu-travail/normes-travail-federales.html", 1],
+            ["COMPENSATION", "https://www.canada.ca/fr/services/emplois/milieu-travail/sante-securite/indemnisation.html", 1],
+            ["HEALTH-SAFETY", "https://www.canada.ca/fr/services/emplois/milieu-travail/sante-securite.html", 1]
+        ]
+    },
+    "page_blacklist": {
+        "en": [
+            "/en/news/",
+            "/en/employment-social-development/programs/laws-regulations/labour/interpretations-policies.html"
+        ],
+        "fr": [
+            "/fr/nouvelles.html",
+            "/fr/emploi-developpement-social/programmes/lois-reglements/travail/interpretations-politiques.html"
+        ]
+    }
+}

--- a/db_config.py
+++ b/db_config.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+import json
+from pathlib import Path
 
 from chromadb import EmbeddingFunction
 from sentence_transformers import SentenceTransformer
@@ -34,105 +36,29 @@ class ModelsConfig:
 
 @dataclass
 class VectorDBDataFiles:
-    databases = [
-        {
-            "name": "labour",
-            "is_default": True,
-            "save_html": True,
-            "languages": ["en", "fr"],
-            "ressource_name": {
-                "en": "Labour",
-                "fr": "Travail"
-            },
-            "ipg": {
-                "en": "https://www.canada.ca/en/employment-social-development/programs/laws-regulations/labour/interpretations-policies.html",
-                "fr": "https://www.canada.ca/fr/emploi-developpement-social/programmes/lois-reglements/travail/interpretations-politiques.html"
-            },
-            "law": {
-                "en": [
-                    ("clc", "https://laws-lois.justice.gc.ca/eng/acts/l-2/"),
-                    ("clsr", "https://laws-lois.justice.gc.ca/eng/regulations/C.R.C.,_c._986/")
-
-                ],
-                "fr": [
-                    ("clc", "https://laws-lois.justice.gc.ca/fra/lois/l-2/"),
-                    ("clsr", "https://laws-lois.justice.gc.ca/fra/reglements/C.R.C.%2C_ch._986/")
-                ]
-            },
-            "page": {
-                "en": [
-                    ("LABOUR", "https://www.canada.ca/en/employment-social-development/corporate/portfolio/labour.html", 1),
-                    ("WORKPLACE", "https://www.canada.ca/en/services/jobs/workplace.html", 1),
-                    ("LABOUR-REPORTS", "https://www.canada.ca/en/employment-social-development/corporate/portfolio/labour/programs/labour-standards/reports.html", 1),
-                    ("LABOUR-STANDARDS", "https://www.canada.ca/en/services/jobs/workplace/federal-labour-standards.html", 1),
-                    ("COMPENSATION", "https://www.canada.ca/en/services/jobs/workplace/health-safety/compensation.html", 1),
-                    ("HEALTH-SAFETY", "https://www.canada.ca/en/services/jobs/workplace/health-safety.html", 1)
-                ],
-                "fr": [
-                    ("LABOUR", "https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/travail.html", 1),
-                    ("WORKPLACE", "https://www.canada.ca/fr/services/emplois/milieu-travail.html", 1),
-                    ("LABOUR-REPORTS", "https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/travail/programmes/normes-travail/rapports.html", 1),
-                    ("LABOUR-STANDARDS", "https://www.canada.ca/fr/services/emplois/milieu-travail/normes-travail-federales.html", 1),
-                    ("COMPENSATION", "https://www.canada.ca/fr/services/emplois/milieu-travail/sante-securite/indemnisation.html", 1),
-                    ("HEALTH-SAFETY", "https://www.canada.ca/fr/services/emplois/milieu-travail/sante-securite.html", 1)
-                ]
-            },
-            "page_blacklist": {
-                "en": [
-                    "/en/news/",
-                    "/en/employment-social-development/programs/laws-regulations/labour/interpretations-policies.html"
-                ],
-                "fr": [
-                    "/fr/nouvelles.html",
-                    "/fr/emploi-developpement-social/programmes/lois-reglements/travail/interpretations-politiques.html"
-                ]
-            }
-        },
-        {
-            "name": "equity",
-            "languages": ["en", "fr"],
-            "ressource_name": {
-                "en": "Equity",
-                "fr": "Équité"
-            },
-            "pdf": {
-                "en": [
-                    "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-WEDWEIMSUserGuide-20220224-PDF%20(1).pdf",
-                    "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/EmployerOnboardingGuide-LEEP-2024.pdf",
-                    "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/Taking%20action%20on%20your%20employment%20equity%20data.pdf",
-                    "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-WEDWorkshopHowToInterpretForm2,%20parts%20D-G-20220427.pdf",
-                    "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-WEDStep-by-step%20guide%20for%20annual%20Legislated%20Employment%20Equity%20Program%20(LEEP)%20reporting.pdf",
-                    "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/EmployerOnboardingGuide-FCP-2024.pdf",
-                    "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-WEDHowToImproveWorkplaceEquity-20230308-PDF.pdf"
-                ],
-                "fr": [
-                    "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-WEDWEIMSUserGuideFR-20220224-PDF%20(1).pdf",
-                    "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/GuideDIntegrationPourLesEmployeurs-PLEME-2024.pdf",
-                    "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/Agir%20a%20partir%20de%20vos%20donnees%20sur%20l%20equite%20en%20emploi.pdf",
-                    "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-WEDAtelierCommentInterpreterVotreFormulaire%202,%20parties%20D-G-20220428.pdf",
-                    "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-Guide%20de%20preparation%20etape%20par%20etape%20du%20rapport%20annuel%20du%20Programme%20legifere%20dequite%20en%20matiere%20demploi%20(PLEME).pdf",
-                    "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/GuideDIntegrationPourLesEmployeurs-PCF-2024.pdf",
-                    "https://equity.esdc.gc.ca/sgiemt-weims/maint/file/download/FP-GC-WEDCommentAmeliorerLequiteSurLeLieuDuTravailFR-20230308-PDF.pdf"
-                ]
-            }
-        }
-        # ,{
-        #     "name": "another_use_case",
-        #     "is_default": True,           #<----- If True, this will be the default database in the app (if true for multiple databases, the first one will be the default)
-        #     "save_html": True,            #<----- If True, the html files of all web pages will be saved in the "outputs" folder
-        #     "languages": ["en"],
-        #     "ressource_name": {
-        #         "en": "Another use case"
-        #     },
-        #     "pdf": {
-        #         "en": [
-        #             "https://www.example.com/pdf/example.pdf",  #<----- Remote pdf
-        #             "C:/test.pdf"                               #<----- Local pdf file
-        #             "../use_case_x/"                            #<----- Local folder with pdfs
-        #         ] 
-        #     }
-        # }
-    ]
+    _databases = None
+    
+    # Lazily load databases from JSON files in collections folder
+    @classmethod
+    def databases(cls):
+        if cls._databases is None:
+            cls._databases = []
+            collections_dir = Path("collections")
+            
+            if collections_dir.exists():
+                # Get all .json files in collections directory
+                json_files = list(collections_dir.glob("*.json"))
+                
+                for json_file in json_files:
+                    try:
+                        with open(json_file, 'r', encoding='utf-8') as f:
+                            data = json.load(f)
+                            cls._databases.append(data)
+                    except (json.JSONDecodeError, FileNotFoundError, UnicodeDecodeError) as e:
+                        print(f"Warning: Could not load {json_file}: {e}")
+                        continue
+        
+        return cls._databases
 
 @dataclass
 class FilteredMTEB:

--- a/db_config.py
+++ b/db_config.py
@@ -52,6 +52,7 @@ class VectorDBDataFiles:
                 "en": [
                     ("clc", "https://laws-lois.justice.gc.ca/eng/acts/l-2/"),
                     ("clsr", "https://laws-lois.justice.gc.ca/eng/regulations/C.R.C.,_c._986/")
+
                 ],
                 "fr": [
                     ("clc", "https://laws-lois.justice.gc.ca/fra/lois/l-2/"),
@@ -60,20 +61,20 @@ class VectorDBDataFiles:
             },
             "page": {
                 "en": [
-                    ("LABOUR", "https://www.canada.ca/en/employment-social-development/corporate/portfolio/labour.html"),
-                    ("WORKPLACE", "https://www.canada.ca/en/services/jobs/workplace.html"),
-                    ("LABOUR-REPORTS", "https://www.canada.ca/en/employment-social-development/corporate/portfolio/labour/programs/labour-standards/reports.html"),
-                    ("LABOUR-STANDARDS", "https://www.canada.ca/en/services/jobs/workplace/federal-labour-standards.html"),
-                    ("COMPENSATION", "https://www.canada.ca/en/services/jobs/workplace/health-safety/compensation.html"),
-                    ("HEALTH-SAFETY", "https://www.canada.ca/en/services/jobs/workplace/health-safety.html")
+                    ("LABOUR", "https://www.canada.ca/en/employment-social-development/corporate/portfolio/labour.html", 1),
+                    ("WORKPLACE", "https://www.canada.ca/en/services/jobs/workplace.html", 1),
+                    ("LABOUR-REPORTS", "https://www.canada.ca/en/employment-social-development/corporate/portfolio/labour/programs/labour-standards/reports.html", 1),
+                    ("LABOUR-STANDARDS", "https://www.canada.ca/en/services/jobs/workplace/federal-labour-standards.html", 1),
+                    ("COMPENSATION", "https://www.canada.ca/en/services/jobs/workplace/health-safety/compensation.html", 1),
+                    ("HEALTH-SAFETY", "https://www.canada.ca/en/services/jobs/workplace/health-safety.html", 1)
                 ],
                 "fr": [
-                    ("LABOUR", "https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/travail.html"),
-                    ("WORKPLACE", "https://www.canada.ca/fr/services/emplois/milieu-travail.html"),
-                    ("LABOUR-REPORTS", "https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/travail/programmes/normes-travail/rapports.html"),
-                    ("LABOUR-STANDARDS", "https://www.canada.ca/fr/services/emplois/milieu-travail/normes-travail-federales.html"),
-                    ("COMPENSATION", "https://www.canada.ca/fr/services/emplois/milieu-travail/sante-securite/indemnisation.html"),
-                    ("HEALTH-SAFETY", "https://www.canada.ca/fr/services/emplois/milieu-travail/sante-securite.html")
+                    ("LABOUR", "https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/travail.html", 1),
+                    ("WORKPLACE", "https://www.canada.ca/fr/services/emplois/milieu-travail.html", 1),
+                    ("LABOUR-REPORTS", "https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/travail/programmes/normes-travail/rapports.html", 1),
+                    ("LABOUR-STANDARDS", "https://www.canada.ca/fr/services/emplois/milieu-travail/normes-travail-federales.html", 1),
+                    ("COMPENSATION", "https://www.canada.ca/fr/services/emplois/milieu-travail/sante-securite/indemnisation.html", 1),
+                    ("HEALTH-SAFETY", "https://www.canada.ca/fr/services/emplois/milieu-travail/sante-securite.html", 1)
                 ]
             },
             "page_blacklist": {

--- a/scripts/create_database_with_specific_embeddings.py
+++ b/scripts/create_database_with_specific_embeddings.py
@@ -69,8 +69,8 @@ def main(collection_name:str,
                 "id": df.id.values,
                 "title": df.title.values,
                 "hierarchy": df.hierarchy.values,
-                "section_number": df.section_number.values.tolist(), #convert to list to avoid type errors (int64)
-                "main_section_number": df.section_number.apply(lambda x: x.split('.')[0] if isinstance(x, str) and '.' in x else x).values.tolist(), #convert to list to avoid type errors (int64)
+                "section_number": df.section_number.apply(lambda x: str(x)).values.tolist(), #convert to list to avoid type errors (int64)
+                "main_section_number": df.section_number.apply(lambda x: x.split('.')[0] if isinstance(x, str) and '.' in x else str(x)).values.tolist(), #convert to list to avoid type errors (int64)
                 "hyperlink": df.hyperlink.values
             }
             

--- a/scripts/create_database_with_specific_embeddings.py
+++ b/scripts/create_database_with_specific_embeddings.py
@@ -221,7 +221,7 @@ if __name__ == "__main__":
     selected_model = EmbeddingModel(model_name=ModelsConfig.models["multi_qa"], trust_remote_code=True)
     selected_model.assign_model_and_attributes()
 
-    databases = VectorDBDataFiles.databases
+    databases = VectorDBDataFiles.databases()
 
     for db in databases:
         db_name = db["name"]

--- a/scripts/create_database_with_specific_embeddings.py
+++ b/scripts/create_database_with_specific_embeddings.py
@@ -228,7 +228,7 @@ if __name__ == "__main__":
         languages = db.get("languages", ["en", "fr"])  # Default to both languages if not specified
         model_name = selected_model.model_name + "_" + db_name.lower()
 
-        root_path = f"outputs/{db_name}/"
+        root_path = f"extracted_data/{db_name}/"
         data_files_tuples = []
         
         # Create data files tuples for each type of data file

--- a/scripts/create_database_with_specific_embeddings.py
+++ b/scripts/create_database_with_specific_embeddings.py
@@ -41,6 +41,10 @@ def main(collection_name:str,
         language_suffix = "_fr" if current_language == "fr" else ""
         filename = filename_arg + language_suffix
 
+        if not os.path.exists(filename + ".csv"):
+            print(f"Warning: File {filename + '.csv'} does not exist")
+            return
+
         # Load and clean page data
         df = pd.read_csv(filename + ".csv", encoding='utf-8')
         df.fillna(value="N/A", inplace=True)
@@ -65,8 +69,8 @@ def main(collection_name:str,
                 "id": df.id.values,
                 "title": df.title.values,
                 "hierarchy": df.hierarchy.values,
-                "section_number": df.section_number.values,
-                "main_section_number": df.section_number.apply(lambda x: x.split('.')[0] if isinstance(x, str) and '.' in x else x).values,
+                "section_number": df.section_number.values.tolist(), #convert to list to avoid type errors (int64)
+                "main_section_number": df.section_number.apply(lambda x: x.split('.')[0] if isinstance(x, str) and '.' in x else x).values.tolist(), #convert to list to avoid type errors (int64)
                 "hyperlink": df.hyperlink.values
             }
             
@@ -132,6 +136,10 @@ def main(collection_name:str,
                 
                 documents.append(chunk['text'])
                 ids.append(chunk['id'])
+
+        if len(augmented_passages) == 0:
+            print(f"Warning: No augmented passages found for {filename + '_chunks.csv'}")
+            return
 
         # Generate embeddings and upsert to collection in batches
         embeddings = model.model_chroma_callable(augmented_passages)

--- a/scripts/extract_for_database.py
+++ b/scripts/extract_for_database.py
@@ -15,7 +15,7 @@ from db_config import VectorDBDataFiles
 from rag.rag_extractor import RagExtractor
 
 if __name__ == "__main__":
-    databases = VectorDBDataFiles.databases
+    databases = VectorDBDataFiles.databases()
     extractor = RagExtractor()
 
     for db in databases:

--- a/scripts/extract_for_database.py
+++ b/scripts/extract_for_database.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
         save_html = db.get("save_html", False)
         print(f"Processing {db_name}...")
 
-        os.makedirs(f"outputs/{db_name}", exist_ok=True)
+        os.makedirs(f"extracted_data/{db_name}", exist_ok=True)
 
         db_ipg = db.get("ipg")
         if db_ipg:

--- a/scripts/extract_links_transport_acts_and_reg.py
+++ b/scripts/extract_links_transport_acts_and_reg.py
@@ -1,3 +1,25 @@
+"""
+Extract Transport Canada Acts and Regulations Links
+
+This script scrapes Transport Canada's website to collect links to all transport acts and regulations,
+then generates a database collection configuration file for the Canada Labour Research Assistant.
+
+What it does:
+1. Scrapes https://tc.canada.ca/en/corporate-services/acts-regulations/list-regulations
+2. Scrapes https://tc.canada.ca/en/corporate-services/acts-regulations/list-acts  
+3. Filters and processes the links to only include valid law pages
+4. Creates collections/transport_act_reg.json with the structured data
+
+Usage:
+1. Uncomment the line that calls this script in setup/create_or_update_database.sh
+2. Run the database creation script:
+   ./setup/create_or_update_database.sh
+
+Alternatively, run manually:
+  python scripts/extract_links_transport_acts_and_reg.py
+  ./setup/create_or_update_database.sh
+"""
+
 import requests
 import os
 import json
@@ -128,7 +150,7 @@ for link in all_links:
         not_included_pages.append(link)
 
 # Save the transport_act_reg object as JSON
-with open('scripts/outputs/transport_act_reg.json', 'w', encoding='utf-8') as f:
+with open('collections/transport_act_reg.json', 'w', encoding='utf-8') as f:
     json.dump(transport_act_reg, f, indent=2, ensure_ascii=False)
 
 if len(not_included_pages) > 0:

--- a/scripts/extract_links_transport_acts_and_reg.py
+++ b/scripts/extract_links_transport_acts_and_reg.py
@@ -1,0 +1,148 @@
+import requests
+import os
+import json
+from rag.page_utils import safe_beautifulsoup
+
+# Process href by normalizing protocol, adding base URL if needed, and removing unwanted suffixes.
+def process_href(href, base_url="https://tc.canada.ca"):
+    if not href:
+        return None
+    
+    # Replace http with https
+    if href.startswith('http://'):
+        href = href.replace('http://', 'https://')
+    elif not href.startswith('https://'):
+        href = base_url + href
+    
+    # Remove / at the end, if any
+    href = href.rstrip('/')
+    
+    # Remove /page-1.html or /index.html from the end
+    if href.endswith('/page-1.html'):
+        href = href[:-len('/page-1.html')]
+    elif href.endswith('/index.html'):
+        href = href[:-len('/index.html')]
+    elif href.endswith('/FullText.html'):
+        href = href[:-len('/FullText.html')]
+    
+    return href
+
+# Download from https://tc.canada.ca/en/corporate-services/acts-regulations/list-regulations
+url = "https://tc.canada.ca/en/corporate-services/acts-regulations/list-regulations"
+response = requests.get(url)
+response.raise_for_status()
+
+with safe_beautifulsoup(response.content) as soup:
+    # Get only the first div with the specified class
+    div = soup.find('div', class_='block-field-blocknodetcpagebody')
+    links_all_transport_regulations = []
+
+    if not div:
+        print("No div found with class 'block-field-blocknodetcpagebody'")
+        exit()
+
+    # Loop over all ul elements within the div
+    for ul in div.find_all('ul'):
+        # Loop over all a elements within each ul
+        for a in ul.find_all('a', href=True):
+            href = process_href(a.get('href'))
+            if href:
+                links_all_transport_regulations.append(href)
+
+# Extract acts from the acts page
+acts_url = "https://tc.canada.ca/en/corporate-services/acts-regulations/list-acts"
+acts_response = requests.get(acts_url)
+acts_response.raise_for_status()
+
+with safe_beautifulsoup(acts_response.content) as acts_soup:
+    links_all_transport_acts = []
+
+    tbody = acts_soup.find('tbody')
+
+    if not tbody:
+        print("No tbody found")
+        exit()
+    
+    # Look for the tbody tag and extract all links from them
+    for a in tbody.find_all('a', href=True):
+        href = process_href(a.get('href'))
+        if href:
+            links_all_transport_acts.append(href)
+
+# Create a folder for the links
+os.makedirs('scripts/outputs', exist_ok=True)
+
+# create a set of the links to remove duplicates
+links_all_transport_regulations = list(set(links_all_transport_regulations))
+links_all_transport_acts = list(set(links_all_transport_acts))
+
+# Combine all links from both acts and regulations
+all_links = links_all_transport_acts + links_all_transport_regulations
+
+# Save the regulations to a file
+with open('scripts/outputs/all_transport_regulations_links.txt', 'w', encoding='utf-8') as f:
+    f.writelines(link + '\n' for link in links_all_transport_regulations)
+
+# Save the acts to a file
+with open('scripts/outputs/all_transport_acts_links.txt', 'w', encoding='utf-8') as f:
+    f.writelines(link + '\n' for link in links_all_transport_acts)
+
+# Create a combined file with acts first, then regulations
+with open('scripts/outputs/all_transport_acts_and_regulations_links.txt', 'w', encoding='utf-8') as f:
+    f.writelines(link + '\n' for link in all_links)
+
+# Create transport_act_reg database configuration
+transport_act_reg = {
+    "name": "transport_act_reg",
+    "languages": ["en"],
+    "ressource_name": {
+        "en": "Transport Acts & Regulations"
+    },
+    "law": {
+        "en": []
+    }
+}
+
+law_pages = [
+    "https://laws-lois.justice.gc.ca",
+    "https://lois-laws.justice.gc.ca",
+    "https://laws.justice.gc.ca"
+]
+
+not_included_pages = []
+
+# Process each link and categorize
+for link in all_links:
+    link_id_tuple = None
+    
+    # Extract ID from the last part of the URL for page links too
+    link_id = link.split('/')[-1]
+    if link_id == "royal-assent":
+        link_id = link.split('/')[-2] # Get the previous part of the url
+    link_id_tuple = (link_id, link)
+
+    # Check if link starts with laws-lois.justice.gc.ca or lois-laws.justice.gc.ca
+    if any(link.startswith(page) for page in law_pages):
+        transport_act_reg["law"]["en"].append(link_id_tuple)
+    else:
+        not_included_pages.append(link)
+
+# Save the transport_act_reg object as JSON
+with open('scripts/outputs/transport_act_reg.json', 'w', encoding='utf-8') as f:
+    json.dump(transport_act_reg, f, indent=2, ensure_ascii=False)
+
+if len(not_included_pages) > 0:
+    with open('scripts/outputs/not_included_pages.txt', 'w', encoding='utf-8') as f:
+        f.writelines(link + '\n' for link in not_included_pages)
+
+print("--------------------------------")
+print(f"Created transport_act_reg database configuration with:")
+print(f"  - {len(transport_act_reg['law']['en'])} law links")
+print(f"  - Saved to scripts/outputs/transport_act_reg.json")
+
+if len(not_included_pages) > 0:
+    print("--------------------------------")
+    print("Some pages were not valid law pages, the correct links should be added manually if it can be found.")
+    print(f"  - {len(not_included_pages)} pages not included")
+    print(f"  - Saved to scripts/outputs/not_included_pages.txt")
+    

--- a/scripts/extract_links_transport_acts_and_reg.py
+++ b/scripts/extract_links_transport_acts_and_reg.py
@@ -92,7 +92,7 @@ with safe_beautifulsoup(acts_response.content) as acts_soup:
             links_all_transport_acts.append(href)
 
 # Create a folder for the links
-os.makedirs('outputs', exist_ok=True)
+os.makedirs('extracted_data', exist_ok=True)
 
 # create a set of the links to remove duplicates
 links_all_transport_regulations = list(set(links_all_transport_regulations))
@@ -102,15 +102,15 @@ links_all_transport_acts = list(set(links_all_transport_acts))
 all_links = links_all_transport_acts + links_all_transport_regulations
 
 # Save the regulations to a file
-with open('outputs/all_transport_regulations_links.txt', 'w', encoding='utf-8') as f:
+with open('extracted_data/all_transport_regulations_links.txt', 'w', encoding='utf-8') as f:
     f.writelines(link + '\n' for link in links_all_transport_regulations)
 
 # Save the acts to a file
-with open('outputs/all_transport_acts_links.txt', 'w', encoding='utf-8') as f:
+with open('extracted_data/all_transport_acts_links.txt', 'w', encoding='utf-8') as f:
     f.writelines(link + '\n' for link in links_all_transport_acts)
 
 # Create a combined file with acts first, then regulations
-with open('outputs/all_transport_acts_and_regulations_links.txt', 'w', encoding='utf-8') as f:
+with open('extracted_data/all_transport_acts_and_regulations_links.txt', 'w', encoding='utf-8') as f:
     f.writelines(link + '\n' for link in all_links)
 
 # Create transport_act_reg database configuration
@@ -154,17 +154,17 @@ with open('collections/transport_act_reg.json', 'w', encoding='utf-8') as f:
     json.dump(transport_act_reg, f, indent=2, ensure_ascii=False)
 
 if len(not_included_pages) > 0:
-    with open('outputs/not_included_pages.txt', 'w', encoding='utf-8') as f:
+    with open('extracted_data/not_included_pages.txt', 'w', encoding='utf-8') as f:
         f.writelines(link + '\n' for link in not_included_pages)
 
 print("--------------------------------")
 print(f"Created transport_act_reg database configuration with:")
 print(f"  - {len(transport_act_reg['law']['en'])} law links")
-print(f"  - Saved to outputs/transport_act_reg.json")
+print(f"  - Saved to extracted_data/transport_act_reg.json")
 
 if len(not_included_pages) > 0:
     print("--------------------------------")
     print("Some pages were not valid law pages, the correct links should be added manually if it can be found.")
     print(f"  - {len(not_included_pages)} pages not included")
-    print(f"  - Saved to outputs/not_included_pages.txt")
+    print(f"  - Saved to extracted_data/not_included_pages.txt")
     

--- a/scripts/extract_links_transport_acts_and_reg.py
+++ b/scripts/extract_links_transport_acts_and_reg.py
@@ -92,7 +92,7 @@ with safe_beautifulsoup(acts_response.content) as acts_soup:
             links_all_transport_acts.append(href)
 
 # Create a folder for the links
-os.makedirs('scripts/outputs', exist_ok=True)
+os.makedirs('outputs', exist_ok=True)
 
 # create a set of the links to remove duplicates
 links_all_transport_regulations = list(set(links_all_transport_regulations))
@@ -102,15 +102,15 @@ links_all_transport_acts = list(set(links_all_transport_acts))
 all_links = links_all_transport_acts + links_all_transport_regulations
 
 # Save the regulations to a file
-with open('scripts/outputs/all_transport_regulations_links.txt', 'w', encoding='utf-8') as f:
+with open('outputs/all_transport_regulations_links.txt', 'w', encoding='utf-8') as f:
     f.writelines(link + '\n' for link in links_all_transport_regulations)
 
 # Save the acts to a file
-with open('scripts/outputs/all_transport_acts_links.txt', 'w', encoding='utf-8') as f:
+with open('outputs/all_transport_acts_links.txt', 'w', encoding='utf-8') as f:
     f.writelines(link + '\n' for link in links_all_transport_acts)
 
 # Create a combined file with acts first, then regulations
-with open('scripts/outputs/all_transport_acts_and_regulations_links.txt', 'w', encoding='utf-8') as f:
+with open('outputs/all_transport_acts_and_regulations_links.txt', 'w', encoding='utf-8') as f:
     f.writelines(link + '\n' for link in all_links)
 
 # Create transport_act_reg database configuration
@@ -154,17 +154,17 @@ with open('collections/transport_act_reg.json', 'w', encoding='utf-8') as f:
     json.dump(transport_act_reg, f, indent=2, ensure_ascii=False)
 
 if len(not_included_pages) > 0:
-    with open('scripts/outputs/not_included_pages.txt', 'w', encoding='utf-8') as f:
+    with open('outputs/not_included_pages.txt', 'w', encoding='utf-8') as f:
         f.writelines(link + '\n' for link in not_included_pages)
 
 print("--------------------------------")
 print(f"Created transport_act_reg database configuration with:")
 print(f"  - {len(transport_act_reg['law']['en'])} law links")
-print(f"  - Saved to scripts/outputs/transport_act_reg.json")
+print(f"  - Saved to outputs/transport_act_reg.json")
 
 if len(not_included_pages) > 0:
     print("--------------------------------")
     print("Some pages were not valid law pages, the correct links should be added manually if it can be found.")
     print(f"  - {len(not_included_pages)} pages not included")
-    print(f"  - Saved to scripts/outputs/not_included_pages.txt")
+    print(f"  - Saved to outputs/not_included_pages.txt")
     

--- a/setup/create_or_update_database.sh
+++ b/setup/create_or_update_database.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
+#python ./scripts/extract_links_transport_acts_and_reg.py && # UNCOMMENT TO CREATE TRANSPORT DATABASE
 python ./scripts/extract_for_database.py &&
 python ./scripts/create_database_with_specific_embeddings.py

--- a/src/rag/extract_ipgs.py
+++ b/src/rag/extract_ipgs.py
@@ -165,7 +165,7 @@ if __name__ == "__main__":
     from rag.extract_ipgs import extract_ipgs_main
 
     selected_tokenizer, selected_token_limit = get_tokenizer_and_limit()
-    databases = VectorDBDataFiles.databases
+    databases = VectorDBDataFiles.databases()
 
     for db in databases:
         db_name = db["name"]

--- a/src/rag/extract_ipgs.py
+++ b/src/rag/extract_ipgs.py
@@ -34,7 +34,7 @@ def process_ipg_page(ipg: IPG, database_name, save_html, tokenizer, token_limit,
         language_suffix = "_fr" if current_language != "en" else ""
 
         if save_html:
-            output_dir = f"outputs/{database_name}/ipgs_html{language_suffix}"
+            output_dir = f"extracted_data/{database_name}/ipgs_html{language_suffix}"
             os.makedirs(output_dir, exist_ok=True)
             filename = f"{output_dir}/{ipg.id}{language_suffix}.html"
             

--- a/src/rag/extract_law.py
+++ b/src/rag/extract_law.py
@@ -17,6 +17,8 @@ import requests
 from bs4 import BeautifulSoup, Tag
 from urllib.parse import urlparse
 from typing import List, Optional
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))  # Add the parent directory to sys.path
 
 class SectionItem:
     def __init__(self, section_number: str, title: str, text: str, tag_id: str):
@@ -72,8 +74,13 @@ def parse_toc_items(ul, current_hierarchy, base_url) -> list[TocItem]:
 
 # Fetch the main Labour Code page and parse the table-of-contents recursively.
 def get_main_toc_links(base_url: str) -> list[TocItem]:
-    response = requests.get(base_url, timeout=10)
-    response.raise_for_status()
+    try:
+        response = requests.get(base_url, timeout=10)
+        response.raise_for_status()
+    except Exception as e:
+        print(f"Error fetching {base_url}: {e}")
+        return []
+    
     soup = BeautifulSoup(response.content, 'html.parser')
     
     toc = soup.find('ul', class_='TocIndent')
@@ -82,102 +89,117 @@ def get_main_toc_links(base_url: str) -> list[TocItem]:
 
 def extract_page_text(soup, url, is_schedule = False) -> Optional[List[SectionItem]]:
     parsed_url = urlparse(url)
-    if parsed_url.fragment:
-        header_tags = ["h1", "h2", "h3", "h4", "h5", "h6"]
+    
+    header_tags = ["h1", "h2", "h3", "h4", "h5", "h6"]
 
+    # Find all section and schedule labels
+    section_labels = []
+    label_class = "sectionLabel" if not is_schedule else "scheduleLabel"
+    
+    if parsed_url.fragment:
         # Look for the section header with the matching fragment id
         section_header = soup.find(header_tags, id=parsed_url.fragment)
+        
+        # If no section header is found, return None
         if not section_header:
             print(f"Section with ID '{parsed_url.fragment}' not found in {url}.")
             return None
-        
+            
         # Check if the header is within a <header> tag
         parent_header = section_header.find_parent('header')
         if parent_header:
             section_header = parent_header
             
-        # Find all section and schedule labels within this section's content
-        section_labels = []
+        # Find section/schedule labels within this specific section's content
         current = section_header
-        while current:
+        while current: # Loops through siblings of the section header
             if isinstance(current, Tag):
                 if current.name in header_tags and current != section_header:
                     break
                 # Find any section or schedule labels in this tag
-                label_class = "sectionLabel" if not is_schedule else "scheduleLabel"
                 labels = current.find_all('span', class_=label_class)
                 section_labels.extend(labels)
             current = current.next_sibling
-            
-        # Process each section label to create SectionItems
-        sections = []
-        for label in section_labels:
-            # Get the section number from the label
-            section_number = label.get_text(strip=True).replace("[", "").replace("]", "").replace("Section ", "").strip()
-            
-            # Find the parent container
-            section_container_class = "Section" if not is_schedule else "Schedule"
-            section_container_parent_tags = ['ul', 'p'] if not is_schedule else ['div']
-            section_container = label.find_parent(section_container_parent_tags, class_=section_container_class)
-            if not section_container:
-                continue
+    else:
+        print("Warning: No fragment (id) included in toc, looking through the whole page.")
+        # Search the entire page for all section/schedule labels
+        section_labels = soup.find_all('span', class_=label_class)
+        
+    # Process each section label to create SectionItems
+    sections = []
+    for label in section_labels:
+        # Get the section number from the label
+        section_number = label.get_text(strip=True).replace("[", "").replace("]", "").replace("Section ", "").strip()
+        
+        # Find the parent container
+        section_container_class = "Section" if not is_schedule else "Schedule"
+        section_container_parent_tags = ['ul', 'p'] if not is_schedule else ['div']
+        section_container = label.find_parent(section_container_parent_tags, class_=section_container_class)
+        if not section_container:
+            continue
 
-            section_container_id = section_container.get('id')
+        section_container_id = section_container.get('id')
+            
+        # Find the title - it's in a <p class="MarginalNote"> before the section container
+        title = ""
+        prev_sibling = section_container.previous_sibling
+        while prev_sibling:
+            if isinstance(prev_sibling, Tag):
+                # Stop if we hit a header tag
+                if prev_sibling.name in header_tags:
+                    break
                 
-            # Find the title - it's in a <p class="MarginalNote"> before the section container
-            title = ""
-            prev_sibling = section_container.previous_sibling
-            while prev_sibling:
-                if isinstance(prev_sibling, Tag):
-                    # Stop if we hit a header tag
-                    if prev_sibling.name in header_tags:
-                        break
-                    
-                    if prev_sibling.name == 'p' and 'MarginalNote' in prev_sibling.get('class', []):
-                        # Remove the wb-invisible span before getting text
-                        wb_invisible = prev_sibling.find('span', class_='wb-invisible')
-                        if wb_invisible:
-                            wb_invisible.decompose()
-                        title = prev_sibling.get_text(strip=True)
-                        break
-                prev_sibling = prev_sibling.previous_sibling
-            
-            # Extract text from this section until the next section or header
-            section_text = ""
-            current = section_container
-            
-            while current:
-                if isinstance(current, Tag):
-                    # Stop if we hit a new section, header, or <section> tag
-                    if ('Section' in current.get('class', []) and current != section_container) or \
-                       current.name in header_tags or current.name == 'section':
-                        break
-                    
-                    current_dt = current.find('dfn')
-                    if current_dt:
-                        current_dt.decompose()
-                    
-                    section_text += "\n" + current.get_text(separator="\n", strip=True)
-                current = current.next_sibling
+                if prev_sibling.name == 'p' and 'MarginalNote' in prev_sibling.get('class', []):
+                    # Remove the wb-invisible span before getting text
+                    wb_invisible = prev_sibling.find('span', class_='wb-invisible')
+                    if wb_invisible:
+                        wb_invisible.decompose()
+                    title = prev_sibling.get_text(strip=True)
+                    break
+            prev_sibling = prev_sibling.previous_sibling
+        
+        # Extract text from this section until the next section or header
+        section_text = ""
+        current = section_container
+        
+        while current:
+            if isinstance(current, Tag):
+                # Stop if we hit a new section, header, or <section> tag
+                if ('Section' in current.get('class', []) and current != section_container) or \
+                    current.name in header_tags or current.name == 'section':
+                    break
+                
+                current_dt = current.find('dfn')
+                if current_dt:
+                    current_dt.decompose()
+                
+                section_text += "\n" + current.get_text(separator="\n", strip=True)
+            current = current.next_sibling
 
-            # Remove "Previous Version" from the end of the text (only look from the end)
-            section_text = section_text.rsplit("Previous Version", 1)[0].strip() if section_text.endswith("Previous Version") else section_text
-            section_text = section_text.replace("\n", " ").replace("\r", " ")
-            
-            sections.append(SectionItem(
-                section_number=section_number.replace(" ", "_") if section_number else "",
-                title=title,
-                text=section_text.strip(),
-                tag_id=section_container_id
-            ))
+        # Remove "Previous Version" from the end of the text (only look from the end)
+        section_text = section_text.rsplit("Previous Version", 1)[0].strip() if section_text.endswith("Previous Version") else section_text
+        section_text = section_text.replace("\n", " ").replace("\r", " ")
+        
+        sections.append(SectionItem(
+            section_number=section_number.replace(" ", "_") if section_number else "",
+            title=title,
+            text=section_text.strip(),
+            tag_id=section_container_id
+        ))
         
         return sections
     
     return None
 
 def process_toc_page(toc_url, database_name, file_name, tokenizer, token_limit, current_language):
+    
     print("Fetching table of contents links...")
     toc_items = get_main_toc_links(toc_url)
+
+    if not toc_items or len(toc_items) == 0:
+        print(f"No table of contents links found for {toc_url}")
+        return
+
     print(f"Found {len(toc_items)} leaf links.")
     soup = None
 
@@ -198,74 +220,96 @@ def process_toc_page(toc_url, database_name, file_name, tokenizer, token_limit, 
         section_label.string = f"Section {section_label.get_text(strip=True)}"
 
     language_suffix = "_fr" if current_language != "en" else ""
-    
+
+    final_csv_rows = []
+    all_ids = []
+
+    for toc_item in toc_items:
+        url = requests.compat.urljoin(full_page_url, toc_item.link_url)
+        print(f"Processing: {toc_item.title} - {url}")
+
+        schedule_name = "SCHEDULE" if current_language == "en" else "ANNEXE"
+        is_schedule = schedule_name in toc_item.title
+        sections = extract_page_text(soup, url, is_schedule)
+        if not sections:
+            print(f"No sections found for {url}")
+            continue
+
+        id_prefix = file_name.upper() + "-"
+        
+        # Group sections by their main section number
+        section_groups = {}
+        for section in sections:
+            # Get main section number (before the dot)
+            main_section = section.section_number.split('.')[0]
+            
+            if main_section not in section_groups:
+                section_groups[main_section] = []
+            section_groups[main_section].append(section)
+        
+        # Process each group of sections
+        for main_section, group in section_groups.items():
+            combined_sections = []
+            current_combined = group[0]
+            current_text = current_combined.text
+            
+            for next_section in group[1:]:
+                # Check if combining would exceed token limit
+                combined_text = f"{current_text} {next_section.text}"
+                token_count = len(tokenizer.encode(combined_text))
+                
+                if token_count < token_limit:
+                    # Combine sections
+                    current_text = combined_text
+                    current_combined.text = current_text
+                    current_combined.title = f"{current_combined.title} | {next_section.title}" if current_combined.title else next_section.title
+                else:
+                    # Start new combined section
+                    combined_sections.append(current_combined)
+                    current_combined = next_section
+                    current_text = current_combined.text
+            
+            # Add the last combined section
+            combined_sections.append(current_combined)
+            
+            # Write combined sections to CSV
+            for section in combined_sections:
+                id_text = f"{id_prefix}{section.section_number}"
+                title = toc_item.title + (": " + section.title if section.title and section.title != toc_item.title else "")
+                if section.tag_id:
+                    section_url = requests.compat.urljoin(full_page_url, "#" + section.tag_id)
+                else:
+                    print(f"WARNING: No tag_id for {section.section_number} in {full_page_url}")
+                    section_url = full_page_url
+
+                # If the id_text is already in all_ids, add a counter to the end
+                original_id_text = id_text
+                counter = 1
+                while id_text in all_ids:
+                    id_text = f"{original_id_text}_{counter}"
+                    counter += 1
+                    
+                all_ids.append(id_text)
+                
+                final_csv_rows.append([
+                    id_text,
+                    title,
+                    section.section_number,
+                    toc_item.hierarchy,
+                    section_url,
+                    section.text
+                ])
+
+    if len(final_csv_rows) == 0:
+        print(f"WARNING: No sections found for {full_page_url}")
+
     # Open the CSV file for writing
     with open(f"outputs/{database_name}/{file_name}{language_suffix}.csv", "w", newline="", encoding="utf-8") as csvfile:
         csv_writer = csv.writer(csvfile)
         csv_writer.writerow(["id", "title", "section_number", "hierarchy", "hyperlink", "text"])
 
-        for toc_item in toc_items:
-            url = requests.compat.urljoin(full_page_url, toc_item.link_url)
-            print(f"Processing: {toc_item.title} - {url}")
-
-            schedule_name = "SCHEDULE" if current_language == "en" else "ANNEXE"
-            is_schedule = schedule_name in toc_item.title
-            sections = extract_page_text(soup, url, is_schedule)
-            if not sections:
-                print(f"No sections found for {url}")
-                continue
-
-            id_prefix = file_name.upper() + "-"
-            
-            # Group sections by their main section number
-            section_groups = {}
-            for section in sections:
-                # Get main section number (before the dot)
-                main_section = section.section_number.split('.')[0]
-                
-                if main_section not in section_groups:
-                    section_groups[main_section] = []
-                section_groups[main_section].append(section)
-            
-            # Process each group of sections
-            for main_section, group in section_groups.items():
-                combined_sections = []
-                current_combined = group[0]
-                current_text = current_combined.text
-                
-                for next_section in group[1:]:
-                    # Check if combining would exceed token limit
-                    combined_text = f"{current_text} {next_section.text}"
-                    token_count = len(tokenizer.encode(combined_text))
-                    
-                    if token_count < token_limit:
-                        # Combine sections
-                        current_text = combined_text
-                        current_combined.text = current_text
-                        current_combined.title = f"{current_combined.title} | {next_section.title}" if current_combined.title else next_section.title
-                    else:
-                        # Start new combined section
-                        combined_sections.append(current_combined)
-                        current_combined = next_section
-                        current_text = current_combined.text
-                
-                # Add the last combined section
-                combined_sections.append(current_combined)
-                
-                # Write combined sections to CSV
-                for section in combined_sections:
-                    id_text = f"{id_prefix}{section.section_number}"
-                    title = toc_item.title + (": " + section.title if section.title and section.title != toc_item.title else "")
-                    section_url = requests.compat.urljoin(full_page_url, "#" + section.tag_id)
-                    
-                    csv_writer.writerow([
-                        id_text,
-                        title,
-                        section.section_number,
-                        toc_item.hierarchy,
-                        section_url,
-                        section.text
-                    ])
+        for row in final_csv_rows:
+            csv_writer.writerow(row)
 
 def extract_law_main(law_dict:dict, database_name:str, selected_tokenizer, selected_token_limit:int):
     for language in law_dict.keys():
@@ -278,6 +322,11 @@ def extract_law_main(law_dict:dict, database_name:str, selected_tokenizer, selec
         os.makedirs(f"outputs/{database_name}", exist_ok=True)
 
         for file_name, toc_url in documents:
+            
+            # If doesn't finish with "/", add it
+            if not toc_url.endswith("/"):
+                toc_url += "/"
+
             process_toc_page(toc_url, database_name, file_name, selected_tokenizer, selected_token_limit, language)
 
 if __name__ == "__main__":

--- a/src/rag/extract_law.py
+++ b/src/rag/extract_law.py
@@ -334,7 +334,7 @@ if __name__ == "__main__":
     from rag.page_utils import get_tokenizer_and_limit
     from rag.extract_law import extract_law_main
 
-    databases = VectorDBDataFiles.databases
+    databases = VectorDBDataFiles.databases()
     selected_tokenizer, selected_token_limit = get_tokenizer_and_limit()
 
     for db in databases:

--- a/src/rag/extract_law.py
+++ b/src/rag/extract_law.py
@@ -304,7 +304,7 @@ def process_toc_page(toc_url, database_name, file_name, tokenizer, token_limit, 
         print(f"WARNING: No sections found for {full_page_url}")
 
     # Open the CSV file for writing
-    with open(f"outputs/{database_name}/{file_name}{language_suffix}.csv", "w", newline="", encoding="utf-8") as csvfile:
+    with open(f"extracted_data/{database_name}/{file_name}{language_suffix}.csv", "w", newline="", encoding="utf-8") as csvfile:
         csv_writer = csv.writer(csvfile)
         csv_writer.writerow(["id", "title", "section_number", "hierarchy", "hyperlink", "text"])
 
@@ -318,8 +318,8 @@ def extract_law_main(law_dict:dict, database_name:str, selected_tokenizer, selec
         #documents = WebCrawlConfig.toc_filenames_and_urls if language == "en" else WebCrawlConfig.toc_filenames_and_urls_fr
         documents = law_dict[language]
 
-        # Create outputs directory if it doesn't exist
-        os.makedirs(f"outputs/{database_name}", exist_ok=True)
+        # Create extracted_data directory if it doesn't exist
+        os.makedirs(f"extracted_data/{database_name}", exist_ok=True)
 
         for file_name, toc_url in documents:
             

--- a/src/rag/extract_page.py
+++ b/src/rag/extract_page.py
@@ -167,6 +167,10 @@ def extract_pages_main(pages_dict:dict, database_name:str, selected_tokenizer, s
 
         #pages_to_process = WebCrawlConfig.canada_pages_ids_and_urls if language == "en" else WebCrawlConfig.canada_pages_ids_and_urls_fr
         pages_to_process = pages_dict[language]
+
+        # If pages_to_process is a list of list, convert to a list of tuples
+        if isinstance(pages_to_process, list) and all(isinstance(item, list) for item in pages_to_process):
+            pages_to_process = [tuple(item) for item in pages_to_process]
         
         # Initialize PROCESSED_LINKS with starting pages
         PROCESSED_LINKS = set(pages_to_process)

--- a/src/rag/extract_page.py
+++ b/src/rag/extract_page.py
@@ -203,7 +203,7 @@ if __name__ == "__main__":
     from rag.page_utils import get_tokenizer_and_limit
 
     selected_tokenizer, selected_token_limit = get_tokenizer_and_limit()
-    databases = VectorDBDataFiles.databases
+    databases = VectorDBDataFiles.databases()
 
     for db in databases:
         db_name = db["name"]

--- a/src/rag/extract_page.py
+++ b/src/rag/extract_page.py
@@ -78,7 +78,7 @@ def save_html_content(content: str, title: str, current_language: str, database_
     with open(filepath, "w", encoding="utf-8") as f:
         f.write(content)
 
-def process_page(url: str, current_depth: int, tokenizer, token_limit: int, current_language: str, database_name: str, save_html: bool, blacklist_urls: List[str], skip_toc: bool = False):
+def process_page(url: str, current_depth: int, tokenizer, token_limit: int, current_language: str, database_name: str, save_html: bool, blacklist_urls: List[str], max_depth: int = 1, skip_toc: bool = False):
     current_processed_pages = []
     print(f"Processing {url} at depth {current_depth}")
     base_url = get_base_url(url)
@@ -103,7 +103,7 @@ def process_page(url: str, current_depth: int, tokenizer, token_limit: int, curr
                     for full_url in toc_links:
                         if full_url not in PROCESSED_LINKS:
                             PROCESSED_LINKS.add(full_url) # Mark as processed
-                            processed_pages = process_page(full_url, current_depth, tokenizer, token_limit, current_language, database_name, save_html, blacklist_urls, skip_toc=True)
+                            processed_pages = process_page(full_url, current_depth, tokenizer, token_limit, current_language, database_name, save_html, blacklist_urls, max_depth, skip_toc=True)
                             current_processed_pages.extend(processed_pages)
                     return current_processed_pages
             
@@ -125,7 +125,7 @@ def process_page(url: str, current_depth: int, tokenizer, token_limit: int, curr
         current_processed_pages.append(page)
         
         # Process linked pages if depth allows
-        if current_depth < 1:
+        if current_depth < max_depth:
             print(f"Processing links from {url} at depth {current_depth}")
             sub_links_to_process = []
                 
@@ -140,7 +140,7 @@ def process_page(url: str, current_depth: int, tokenizer, token_limit: int, curr
             if current_depth == 0:
                 # Process in batches of 10
                 with ThreadPoolExecutor(max_workers=MAX_BATCH_SIZE) as executor:
-                    futures = [executor.submit(process_page, url, current_depth + 1, tokenizer, token_limit, current_language, database_name, save_html, blacklist_urls) for url in sub_links_to_process]
+                    futures = [executor.submit(process_page, url, current_depth + 1, tokenizer, token_limit, current_language, database_name, save_html, blacklist_urls, max_depth) for url in sub_links_to_process]
 
                     # Wait for batch completion and add results in order
                     # for future in sorted(futures.keys(), key=lambda f: futures[f]):
@@ -151,7 +151,7 @@ def process_page(url: str, current_depth: int, tokenizer, token_limit: int, curr
             else:
                 # Process sequentially for depth > 0
                 for link in sub_links_to_process:
-                    processed_pages = process_page(link, current_depth + 1, tokenizer, token_limit, current_language, database_name, save_html, blacklist_urls)
+                    processed_pages = process_page(link, current_depth + 1, tokenizer, token_limit, current_language, database_name, save_html, blacklist_urls, max_depth)
                     current_processed_pages.extend(processed_pages)
 
     except Exception as e:
@@ -181,8 +181,13 @@ def extract_pages_main(pages_dict:dict, database_name:str, selected_tokenizer, s
 
         all_processed_pages = []
         
-        for id_prefix, page_url in pages_to_process:
-            processed_pages = process_page(page_url, 0, selected_tokenizer, selected_token_limit, language, database_name, save_html, blacklist_urls)
+        for id_prefix, page_url, max_depth in pages_to_process:
+
+            if max_depth > 2:
+                print(f"Warning: max_depth is greater than 2 for {id_prefix}, setting to 2")
+                max_depth = 2
+
+            processed_pages = process_page(page_url, 0, selected_tokenizer, selected_token_limit, language, database_name, save_html, blacklist_urls, max_depth)
 
             # Set the id for each page (Otherwise, might not be in order due to parallel processing)
             for idx, page in enumerate(processed_pages):

--- a/src/rag/extract_page.py
+++ b/src/rag/extract_page.py
@@ -53,10 +53,10 @@ def extract_toc_links(soup, base_url) -> List[str]:
             links.append(f"{base_url}{href}")
     return links
 
-# Save HTML content to a file in the outputs/canada_html directory using the page title
+# Save HTML content to a file in the extracted_data/pages_html directory using the page title
 def save_html_content(content: str, title: str, current_language: str, database_name: str):
     language_suffix = "_fr" if current_language != "en" else ""
-    output_dir = os.path.join("outputs", database_name, "pages_html" + language_suffix)
+    output_dir = os.path.join("extracted_data", database_name, "pages_html" + language_suffix)
     os.makedirs(output_dir, exist_ok=True)
     
     # Clean the title for use as filename

--- a/src/rag/extract_pdf.py
+++ b/src/rag/extract_pdf.py
@@ -164,7 +164,7 @@ if __name__ == "__main__":
     from rag.page_utils import get_tokenizer_and_limit
 
     selected_tokenizer, selected_token_limit = get_tokenizer_and_limit()
-    databases = VectorDBDataFiles.databases
+    databases = VectorDBDataFiles.databases()
 
     for db in databases:
         db_name = db["name"]

--- a/src/rag/page_utils.py
+++ b/src/rag/page_utils.py
@@ -247,9 +247,9 @@ def get_page_csv_row(page: Page) -> List[str]:
     return [page.id, page.title, page.url, " / ".join(page.hierarchy), " / ".join(page.url_hierarchy), "|".join(page.linked_pages) if page.linked_pages else "", ";".join(reference_section_number) if reference_section_number else "", page.date_modified]
 
 def save_to_csv(pages: List[Page], database_name: str, filename: str, lang: str, is_pdf: bool = False):
-    os.makedirs(f"outputs/{database_name}", exist_ok=True)
+    os.makedirs(f"extracted_data/{database_name}", exist_ok=True)
     lang_suffix = "_fr" if lang != "en" else ""
-    csv_path = f"outputs/{database_name}/{filename}{lang_suffix}.csv"
+    csv_path = f"extracted_data/{database_name}/{filename}{lang_suffix}.csv"
     existing_page_ids = []
     
     with open(csv_path, 'w', newline='', encoding='utf-8') as f:
@@ -263,7 +263,7 @@ def save_to_csv(pages: List[Page], database_name: str, filename: str, lang: str,
             writer.writerow(get_page_csv_row(page))
             existing_page_ids.append(page.id)
 
-    csv_path = f"outputs/{database_name}/{filename}{lang_suffix}_chunks.csv"
+    csv_path = f"extracted_data/{database_name}/{filename}{lang_suffix}_chunks.csv"
     total_chunks = 0
 
     # Add new code to write chunks CSV

--- a/src/tools.py
+++ b/src/tools.py
@@ -5,6 +5,7 @@ import time
 
 import chromadb
 from chromadb.config import Settings
+from chromadb.errors import NotFoundError
 import streamlit as st
 import torch
 
@@ -32,8 +33,12 @@ def _load_vector_database(language,
 
     collection_name_in_language = collection_name + "_" + db_name.lower() + ("_" + language if language != "en" else "")
 
-    collection = client.get_collection(collection_name_in_language, 
-                                       embedding_function=sentence_transformer_ef)
+    try:
+        collection = client.get_collection(collection_name_in_language, 
+                                           embedding_function=sentence_transformer_ef)
+    except NotFoundError:
+        error_message = f"Collection '{db_name}' is missing. Please run './setup/create_or_update_database.sh' to create it."
+        raise NotFoundError(error_message)
     
     return collection
 


### PR DESCRIPTION
Add a script to extract all the acts and regulations from transport.

Fix issues with laws extraction where it didn't work in some edge cases.

Added the ability to customize the depth level for the webcrawling (max depth = 2, modified to readme to explain it better).

Note : You should ignore whitespaces when looking at the diff for extract_laws, most of the script remained the same except for the spacing.