### PR TITLE
Fix bug LCS optimization length

### DIFF
--- a/src/citation.py
+++ b/src/citation.py
@@ -235,7 +235,7 @@ def truncate_if_above_max_length(text, max_length):
 # Post processing that should always be applied when markdown is used.
 def markdown_post_processing(text: str) -> str:
     # Replace the dollar signs to fix the markdown
-    return text.replace("$", "\$")
+    return text.replace("$", r"\$")
 
 def fix_links_and_emails(text):
     # Email pattern
@@ -362,7 +362,12 @@ def check_words_in_quote_under_threshold(quote):
     return len([word for word in quote.split()]) < QuotationsConfig.min_words_in_quote
 
 # Verifies quotes in an LLM answer against source chunks and adds attribution.
-def verify_and_attribute_quotes(chunks, llm_answer, threshold, include_html=False, include_attribution=False, include_complete_sentence=False):
+def verify_and_attribute_quotes(chunks, 
+                                llm_answer, 
+                                threshold, 
+                                include_html=False, 
+                                include_attribution=False, 
+                                include_complete_sentence=False):
     # Extract regular quotes sections
     quotes = re.findall(r'"([^"]*)"', llm_answer)
     

--- a/src/citation.py
+++ b/src/citation.py
@@ -154,7 +154,7 @@ def find_lcs_length(reference_words, candidate_words, is_find_optimal_lcs = Fals
             
         end_pos = positions[end_scores.index(max(end_scores))]
         end_pos_index = positions.index(end_pos)
-        lcs_length = (lcs_length - start_pos_index) - ((lcs_length - start_pos_index) - end_pos_index)
+        lcs_length = end_pos_index - start_pos_index + 1 # Recalculate the LCS length
 
     return lcs_length, start_pos, end_pos
 

--- a/src/citation.py
+++ b/src/citation.py
@@ -154,7 +154,7 @@ def find_lcs_length(reference_words, candidate_words, is_find_optimal_lcs = Fals
             
         end_pos = positions[end_scores.index(max(end_scores))]
         end_pos_index = positions.index(end_pos)
-        lcs_length = end_pos_index - start_pos_index + 1 # Recalculate the LCS length
+        lcs_length = end_pos_index - start_pos_index + 1
 
     return lcs_length, start_pos, end_pos
 


### PR DESCRIPTION
I'm pretty sure the calculation was wrong when recalculating the LCS length when optimizing for potentially shorter LCS with higher RougeL score (is_find_optimal_lcs  = True). 

I think the reason I never noticed is because the LCS length is basically never used when is_find_optimal_lcs = True. The only place I can find is when checking if "lcs_length > 0" in the find_segment_with_longest_common_subsequence function.

Still, it would be safer to fix it, in case it was used more in the future.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Recalculate the LCS length by updating the formula to correctly compute the difference between the end and start positions.

### Why are these changes being made?

The previous calculation for LCS length was incorrect due to an improper formula, leading to inaccuracies in determining the Length of Longest Common Subsequence (LCS). This update ensures that the LCS length is accurately calculated by directly using the difference between the end and start positions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->